### PR TITLE
Look into SkillRaceClassInfo.dbc for spell class and race fit

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23317,6 +23317,10 @@ bool Player::IsSpellFitByClassAndRace(uint32 spell_id) const
         if (_spell_idx->second->classmask && (_spell_idx->second->classmask & classmask) == 0)
             continue;
 
+        // skip wrong class and race skill saved in SkillRaceClassInfo.dbc
+        if (!GetSkillRaceClassInfo(_spell_idx->second->skillId, getRace(), getClass()))
+            continue;
+
         return true;
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Look into SkillRaceClassInfo.dbc when checking spell for class and race

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:**

Closes #23172

**Tests performed:** 
In game on spell spell Thrown (check issue #23172). Also other spell trainer are not affected (tested)
